### PR TITLE
don't run lrelease in the make target,

### DIFF
--- a/mea.pro
+++ b/mea.pro
@@ -34,7 +34,6 @@ QMAKE_EXTRA_TARGETS += wininstaller
 
 TRANSLATIONS += $$files(mea/translations/*.ts, true)
 lrelease.commands = lrelease $$_FILE_
-lrelease-make_first.commands = lrelease $$_FILE_
 lrelease-qmake_all.commands = lrelease $$_FILE_
 QMAKE_EXTRA_TARGETS += lrelease lrelease-make_first lrelease-qmake_all lrelease-install_subtargets
 


### PR DESCRIPTION
running it in the qmake target is enough, otherwise it keeps on
rebuilding the .qrc file which takes long. if someone alters the translations
[s]he can run make lrelease or qmake manually to update the translation files