### PR TITLE
fix a crash when editing rules

### DIFF
--- a/libnymea-common/types/stateevaluators.cpp
+++ b/libnymea-common/types/stateevaluators.cpp
@@ -27,6 +27,7 @@ QHash<int, QByteArray> StateEvaluators::roleNames() const
 
 void StateEvaluators::addStateEvaluator(StateEvaluator *stateEvaluator)
 {
+    stateEvaluator->setParent(this);
     beginInsertRows(QModelIndex(), m_list.count(), m_list.count());
     m_list.append(stateEvaluator);
     endInsertRows();

--- a/mea/ui/MagicPage.qml
+++ b/mea/ui/MagicPage.qml
@@ -19,10 +19,10 @@ Page {
     }
 
     function addRule() {
-        d.editRulePage = pageStack.push(Qt.resolvedUrl("magic/EditRulePage.qml"), {rule: Engine.ruleManager.createNewRule() });
+        var newRule = Engine.ruleManager.createNewRule();
+        d.editRulePage = pageStack.push(Qt.resolvedUrl("magic/EditRulePage.qml"), {rule: newRule });
         d.editRulePage.StackView.onRemoved.connect(function() {
-            d.editRulePage.rule.destroy()
-            d.editRulePage = null;
+            newRule.destroy();
         })
         d.editRulePage.onAccept.connect(function() {
             d.editRulePage.busy = true;
@@ -76,10 +76,10 @@ Page {
             onDeleteClicked: Engine.ruleManager.removeRule(model.id)
 
             onClicked: {
-                d.editRulePage = pageStack.push(Qt.resolvedUrl("magic/EditRulePage.qml"), {rule: Engine.ruleManager.rules.get(index).clone()})
+                var newRule = Engine.ruleManager.rules.get(index).clone();
+                d.editRulePage = pageStack.push(Qt.resolvedUrl("magic/EditRulePage.qml"), {rule: newRule})
                 d.editRulePage.StackView.onRemoved.connect(function() {
-                    d.editRulePage.rule.destroy();
-                    d.editRulePage = null
+                    newRule.destroy();
                 })
                 d.editRulePage.onAccept.connect(function() {
                     d.editRulePage.busy = true;

--- a/mea/ui/magic/DeviceRulesPage.qml
+++ b/mea/ui/magic/DeviceRulesPage.qml
@@ -28,8 +28,7 @@ Page {
         }
         d.editRulePage = pageStack.push(Qt.resolvedUrl("EditRulePage.qml"), {rule: rule});
         d.editRulePage.StackView.onRemoved.connect(function() {
-            d.editRulePage.rule.destroy();
-            d.editRulePage = null
+            rule.destroy();
         })
         d.editRulePage.onAccept.connect(function() {
             d.editRulePage.busy = true;
@@ -96,9 +95,10 @@ Page {
 
             onDeleteClicked: Engine.ruleManager.removeRule(model.id)
             onClicked: {
-                d.editRulePage = pageStack.push(Qt.resolvedUrl("EditRulePage.qml"), {rule: rulesFilterModel.get(index).clone() })
+                var newRule = rulesFilterModel.get(index).clone();
+                d.editRulePage = pageStack.push(Qt.resolvedUrl("EditRulePage.qml"), {rule: newRule })
                 d.editRulePage.StackView.onRemoved.connect(function() {
-                    d.editRulePage.rule.destroy();
+                    newRule.destroy();
                 })
                 d.editRulePage.onAccept.connect(function() {
                     d.editRulePage.busy = true

--- a/mea/ui/magic/EditRulePage.qml
+++ b/mea/ui/magic/EditRulePage.qml
@@ -185,7 +185,6 @@ Page {
     }
 
     function selectRuleActionData(ruleActions, ruleAction) {
-        print("opening with ruleAction", ruleAction, ruleAction.interfaceName)
         var ruleActionPage = pageStack.push(Qt.resolvedUrl("SelectRuleActionPage.qml"), {text: "Select action", ruleAction: ruleAction, rule: rule });
         ruleActionPage.onBackPressed.connect(function() {
             ruleActionPage.StackView.onRemoved.connect(function() {


### PR DESCRIPTION
there seems to be a race condition in StackView.onRemoved where it sometimes
makes the QML engine crash if accessing context properties from outside the
function context in the handler.

Sometimes it would just print that those properties are undefined and not complete
the handler code, other times however, it does actually find the properties
but crash upon accessing them.